### PR TITLE
Fixed length indicator not updating

### DIFF
--- a/index.html
+++ b/index.html
@@ -517,7 +517,7 @@
 				<div class="row row-margin-top row-margin-bottom">
 					<div class="col-md-2" id="output_label">
 						<span lang="command"></span> <span onclick="refreshOutput()" class="glyphicon glyphicon-refresh"></span><br>
-						<span lang="commandblock"></span>
+						<span lang="commandblock" id="commandblock"></span>
 					</div>
 					<div class="col-md-10">
 						<textarea onkeyup="refreshOutput()" id="outputtextfield" class="form-control"></textarea>


### PR DESCRIPTION
This span was lacking an ID before, so it would always say that the command required a command block.
