### PR TITLE
Fixed language errors in swedish translation

### DIFF
--- a/lang/sv_sv.json
+++ b/lang/sv_sv.json
@@ -9,7 +9,7 @@
 	"donate": {
 		"patreon-button": "Patreon",
 		"support-header": "(Snälla) Stöd den här webbsidan",
-		"paypal-note": "Jag erbjuder inte paypal ett val i listan på grund av avgifter (Stripe drar inte ut avgifter för studenter). Men, om du vill kan du skicka pengar till mig med PayPal via funds@ezekielelin.com",
+		"paypal-note": "Jag erbjuder inte paypal som ett val i listan på grund av avgifter (Stripe drar inte ut avgifter för studenter). Men, om du vill kan du skicka pengar till mig med PayPal via funds@ezekielelin.com",
 		"patreon-text": "Om du donerar månadsvis, kan jag förlita mig på det för att uppgradera servrarna.",
 		"support-subheader": "Jag vill inte lägga annonser på den här webbsidan, snälla donera för att stödja kostnaderna att ha igång den.",
 		"donate-button": "Donera",
@@ -30,7 +30,7 @@
 		"delete-all-saves": "Rensa dina sparade kommandon, men lämna det nuvarande kommandot i huvudredigeraren intakt.",
 		"create-new-save": "Spara ett nytt kommando. Om du vill kan du skriva över ett annat sparat kommando genom att använda samma namn.",
 		"delete-all-snippets": "Rensa ditt nuvarande kommando helt, men bevara dina sparade kommandon.",
-		"show-saves": "Sparade kommandon-hanterare, tillåter dig att spara, ladda in och ta bort kommandon."
+		"show-saves": "Sparade kommandon-hanterare; tillåter dig att spara, ladda in och ta bort kommandon."
 	},
 	"template": {
 		"sign_block": "Skylt (/blockdata)",
@@ -65,8 +65,8 @@
 		},
 		"show": "Öppna inställningar",
 		"hide": "Stäng inställningar",
-		"fontSize": "Förhansvisa typsnittsstorlek",
-		"previewcolor": "Förhandsvisa bakgrundsfärg:",
+		"fontSize": "Typsnittsstorlek för förhandsvisning",
+		"previewcolor": "Bakgrundsfärg för förhandsvisning:",
 		"export": "Exportera",
 		"deleteall": {
 			"body": "Att klicka Radera kommer att ta bort all din text och återställa det till en tom.",
@@ -100,14 +100,14 @@
 		"color_light_purple": "Ljuslila",
 		"color_yellow": "Gul"
 	},
-	"header": "Tellraw Generator för Minecraft 1.7+",
+	"header": "Tellrawgenerator för Minecraft 1.7+",
 	"textsnippets": {
 		"trn": "Översatt",
 		"clickevent": {
 			"runcommand": "Kör kommando",
 			"openurl": "Öppna URL",
 			"suggestcommand": "Föreslå kommando",
-			"header": "Klickåtgärd:",
+			"header": "Åtgärd när mus klickas:",
 			"none": "Ingen"
 		},
 		"editsnippet": "Redigera text",
@@ -118,7 +118,7 @@
 			"header": "Åtgärd när mus förs över:",
 			"showachievement": "Visa prestation",
 			"showentity": "Visa objekt",
-			"showitem": "Visa sak",
+			"showitem": "Visa föremål",
 			"type": "Typ:",
 			"none": "Ingen",
 			"showtext": "Visa text",
@@ -141,7 +141,7 @@
 		},
 		"player": "Spelare",
 		"obj2": "Mål:",
-		"obj": "Poängtavelsmål:",
+		"obj": "Poängtavelsmål",
 		"nosnippets": "Ingen text än",
 		"header": "Textsnuttar",
 		"raw": "Rå",


### PR DESCRIPTION
Comments:
103: Fixed two-pass.
110: Changed to match the hover header.
121: Changed to the synonym used in in-game translation.
68 & 69: Fixed grammatical error because lack of context.
