### PR TITLE
Put languages in alphabetical order

### DIFF
--- a/resources.json
+++ b/resources.json
@@ -916,20 +916,20 @@
 		"achievement.overpowered"
 	],
 	"web_language_urls": [
+		"cs_cz",
+		"de_de",
 		"en_us",
+		"es_es",
 		"fr_fr",
+		"he_il",
+		"cro_hr",
+		"it",
+		"nl",
 		"pt_br",
 		"ru_ru",
-		"es_es",
-		"zh_tw",
+		"sv_sv",
 		"zh_cn",
-		"nl",
-		"it",
-		"he_il",
-		"de_de",
-		"cs_cz",
-		"cro_hr",
-		"sv_sv"
+		"zh_tw"
 	],
 	"web_language_relations": {
 		"ita": "it",


### PR DESCRIPTION
For non-latin characters I used the language code. I treated the [cyrillic capital letter er 'Р'](http://unicode-table.com/en/0420/) as a P.