### PR TITLE
Changed line-height of 'mover-row' to 'row' height

### DIFF
--- a/css/tellraw.css
+++ b/css/tellraw.css
@@ -128,7 +128,7 @@ div[class*='col-xs-'] {
 }
 
 .mover-row {
-	line-height: 34px;
+	line-height: 44px;
 }
 
 /** {*/


### PR DESCRIPTION
A fix for #48
![image](https://cloud.githubusercontent.com/assets/7348146/5784748/cacfa3b4-9dcf-11e4-9442-6512b80d119a.png)