### PR TITLE
Remove user agent stylesheets' blue outline from from preview back and forward buttons

### DIFF
--- a/css/tellraw.css
+++ b/css/tellraw.css
@@ -43,6 +43,9 @@
 .modal {
 	color: black;
 }
+.no-focus-outline:focus {
+	outline: none;
+}
 @font-face {
 	font-family: 'minecraftiaregular';
 	src: url('../minecraftia/minecraftia-webfont.eot');

--- a/index.html
+++ b/index.html
@@ -870,8 +870,8 @@
 			</div>
 			<div class="col-xs-12 row-margin-top row-margin-bottom col-sm-10">
 				<div id="jsonPreview" lang="output.nothing" style="color:white;"></div>
-				<button id="previewBack"></button>
-				<button id="previewForwards"></button>
+				<button class="no-focus-outline" id="previewBack"></button>
+				<button class="no-focus-outline" id="previewForwards"></button>
 				<span id="previewPage"></span>
 			</div>
 		</div>


### PR DESCRIPTION
![screenshot 2015-01-20 at 21 57 58](https://cloud.githubusercontent.com/assets/7348146/5825948/73ce79b4-a0ef-11e4-8bf9-ce931c624e21.png)
